### PR TITLE
applies base64 encoding on the client context

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -3,6 +3,7 @@ package lambda
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"io/ioutil"
@@ -56,7 +57,7 @@ func BackendFactoryWithInvoker(bf proxy.BackendFactory, invokerFactory func(*Opt
 				return nil, err
 			}
 			input := &lambda.InvokeInput{
-				ClientContext:  aws.String("KrakenD"),
+				ClientContext:  aws.String(base64.StdEncoding.EncodeToString([]byte("KrakenD"))),
 				FunctionName:   aws.String(ecfg.FunctionExtractor(r)),
 				InvocationType: aws.String("RequestResponse"),
 				LogType:        aws.String("Tail"),

--- a/backend_test.go
+++ b/backend_test.go
@@ -80,7 +80,7 @@ func TestBackendFactoryWithInvoker(t *testing.T) {
 				if *in.InvocationType != "RequestResponse" {
 					t.Errorf("unexpected InvocationType: %s", *in.InvocationType)
 				}
-				if *in.ClientContext != "KrakenD" {
+				if *in.ClientContext != "S3Jha2VuRA==" {
 					t.Errorf("unexpected ClientContext: %s", *in.ClientContext)
 				}
 				if *in.FunctionName != "python37" {
@@ -221,7 +221,7 @@ func TestBackendFactoryWithInvoker_error(t *testing.T) {
 				if *in.InvocationType != "RequestResponse" {
 					t.Errorf("unexpected InvocationType: %s", *in.InvocationType)
 				}
-				if *in.ClientContext != "KrakenD" {
+				if *in.ClientContext != "S3Jha2VuRA==" {
 					t.Errorf("unexpected ClientContext: %s", *in.ClientContext)
 				}
 				if *in.FunctionName != "python37" {
@@ -279,7 +279,7 @@ func TestBackendFactoryWithInvoker_incomplete(t *testing.T) {
 				if *in.InvocationType != "RequestResponse" {
 					t.Errorf("unexpected InvocationType: %s", *in.InvocationType)
 				}
-				if *in.ClientContext != "KrakenD" {
+				if *in.ClientContext != "S3Jha2VuRA==" {
 					t.Errorf("unexpected ClientContext: %s", *in.ClientContext)
 				}
 				if *in.FunctionName != "" {


### PR DESCRIPTION
We ran into problems using this module when invoking a Lambda function. It turns out it is required to apply base64 encoding on the client context. The example provided in `aws-sdk-go` misses this as mentioned in https://github.com/aws/aws-sdk-go/issues/1764.

This change applies the encoding on the ClientContext.