### PR TITLE
Add entity formatter

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -50,6 +50,8 @@ func BackendFactoryWithInvoker(bf proxy.BackendFactory, invokerFactory func(*Opt
 
 		i := invokerFactory(ecfg)
 
+		ef := proxy.NewEntityFormatter(remote)
+
 		return func(ctx context.Context, r *proxy.Request) (*proxy.Response, error) {
 			payload, err := ecfg.PayloadExtractor(r)
 			if err != nil {
@@ -76,20 +78,20 @@ func BackendFactoryWithInvoker(bf proxy.BackendFactory, invokerFactory func(*Opt
 			if err := json.Unmarshal(result.Payload, &data); err != nil {
 				return nil, err
 			}
-			response := &proxy.Response{
+			response := ef.Format(proxy.Response{
 				Metadata: proxy.Metadata{
 					StatusCode: int(*result.StatusCode),
 					Headers:    map[string][]string{},
 				},
 				Data:       data,
 				IsComplete: true,
-			}
+			})
 
 			if result.ExecutedVersion != nil {
 				response.Metadata.Headers["X-Amz-Executed-Version"] = []string{*result.ExecutedVersion}
 			}
 
-			return response, nil
+			return &response, nil
 		}
 	}
 }

--- a/backend_test.go
+++ b/backend_test.go
@@ -98,7 +98,7 @@ func TestBackendFactoryWithInvoker(t *testing.T) {
 					t.Errorf("last_name not present in the payload request")
 				}
 				return &lambda.InvokeOutput{
-					Payload:    []byte(fmt.Sprintf(`{"message":"Hello %s %s!"}`, payload["first_name"], payload["last_name"])),
+					Payload:    []byte(fmt.Sprintf(`{"message":"Hello %s %s!", "foo": 42}`, payload["first_name"], payload["last_name"])),
 					StatusCode: aws.Int64(200),
 				}, nil
 			})
@@ -182,7 +182,8 @@ func TestBackendFactoryWithInvoker(t *testing.T) {
 			}
 			extra := map[string]interface{}{}
 			remote := &config.Backend{
-				Method: tc.Method,
+				Method:    tc.Method,
+				Blacklist: []string{"foo"},
 				ExtraConfig: config.ExtraConfig{
 					Namespace: extra,
 				},
@@ -202,6 +203,9 @@ func TestBackendFactoryWithInvoker(t *testing.T) {
 				t.Errorf("%d: incomplete response", i)
 			}
 			if m, ok := resp.Data["message"]; !ok || m != tc.ExpectedMsg {
+				t.Errorf("unexpected response: %v", resp.Data)
+			}
+			if _, ok := resp.Data["foo"]; ok {
 				t.Errorf("unexpected response: %v", resp.Data)
 			}
 		})


### PR DESCRIPTION
the backend should load the entity formatter, so responses can be manipulated as usual