### PR TITLE
Use None LogType for Lambda invoke

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -182,5 +182,5 @@ func fromParams(r *proxy.Request) ([]byte, error) {
 }
 
 func fromBody(r *proxy.Request) ([]byte, error) {
-	return ioutil.ReadAll(r.Body)
+	return io.ReadAll(r.Body)
 }

--- a/backend.go
+++ b/backend.go
@@ -71,7 +71,7 @@ func BackendFactoryWithInvoker(logger logging.Logger, bf proxy.BackendFactory, i
 				// ClientContext:  aws.String(clientContext),
 				FunctionName:   aws.String(ecfg.FunctionExtractor(r)),
 				InvocationType: aws.String("RequestResponse"),
-				LogType:        aws.String("Tail"),
+				LogType:        aws.String("None"),
 				Payload:        payload,
 				// Qualifier:      aws.String("1"),
 			}

--- a/test/localstack_test.go
+++ b/test/localstack_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"flag"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -49,7 +48,7 @@ func TestLocalStack(t *testing.T) {
 			Name:        "post_with_default_key",
 			Method:      "POST",
 			Params:      map[string]string{"function": "python37"},
-			Body:        ioutil.NopCloser(bytes.NewBufferString(`{"first_name":"foobar","last_name":"some"}`)),
+			Body:        io.NopCloser(bytes.NewBufferString(`{"first_name":"foobar","last_name":"some"}`)),
 			ExpectedMsg: "Hello foobar some!",
 		},
 		{
@@ -63,7 +62,7 @@ func TestLocalStack(t *testing.T) {
 			Name:        "post_with_custom_key",
 			Method:      "POST",
 			Params:      map[string]string{"function": "unknown", "lambda": "python37"},
-			Body:        ioutil.NopCloser(bytes.NewBufferString(`{"first_name":"foobar","last_name":"some"}`)),
+			Body:        io.NopCloser(bytes.NewBufferString(`{"first_name":"foobar","last_name":"some"}`)),
 			Key:         "lambda",
 			ExpectedMsg: "Hello foobar some!",
 		},
@@ -78,7 +77,7 @@ func TestLocalStack(t *testing.T) {
 			Name:        "post_with_function_name",
 			Method:      "POST",
 			Params:      map[string]string{"function": "unknown"},
-			Body:        ioutil.NopCloser(bytes.NewBufferString(`{"first_name":"foobar","last_name":"some"}`)),
+			Body:        io.NopCloser(bytes.NewBufferString(`{"first_name":"foobar","last_name":"some"}`)),
 			ExpectedMsg: "Hello foobar some!",
 			Function:    "python37",
 		},
@@ -94,7 +93,7 @@ func TestLocalStack(t *testing.T) {
 			Name:        "post_with_function_name_and_key",
 			Method:      "POST",
 			Params:      map[string]string{"function": "unknown", "lambda": "unknown"},
-			Body:        ioutil.NopCloser(bytes.NewBufferString(`{"first_name":"foobar","last_name":"some"}`)),
+			Body:        io.NopCloser(bytes.NewBufferString(`{"first_name":"foobar","last_name":"some"}`)),
 			Key:         "lambda",
 			ExpectedMsg: "Hello foobar some!",
 			Function:    "python37",


### PR DESCRIPTION
Logs from Lambda invoke are not used, so we could reduce processing time by not requesting them.

It will save 4KB of payload per each invoke.